### PR TITLE
FeedCreator now uses user input to set feed url

### DIFF
--- a/app/services/feed_creator.rb
+++ b/app/services/feed_creator.rb
@@ -6,8 +6,8 @@ class FeedCreator
 
   def create_feed(current_account, url:)
     feed = current_account.feeds.build
-    title, feed_url = retreive_feed(url)
-    feed.assign_attributes(name: title, url: feed_url)
+    parsed_feed = retrieve_feed(url)
+    feed.assign_attributes(name: parsed_feed.title, url: url)
     feed.save
 
     Result.new(created: feed.valid?, feed: feed)
@@ -18,10 +18,9 @@ class FeedCreator
 
   private
 
-  def retreive_feed(url)
+  def retrieve_feed(url)
     xml = @http.get(url).body
-    feed = @parser.parse(xml)
-    [feed.title, feed.feed_url]
+    @parser.parse(xml)
   end
 
   class Result


### PR DESCRIPTION
Originally we were using the feed_url attribute from the parsed feed.
However, this is not always set so instead if we find a feed
we just save what the user provided.

This means that we're only really using the feed title.