### PR TITLE
Lets user set last_fetched_at on adding feed

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -15,7 +15,11 @@ class FeedsController < ApplicationController
   end
 
   def create
-    result = FeedCreator.new.create_feed(current_account, url: feed_params[:url])
+    result = FeedCreator.new.create_feed(
+      current_account,
+      url: feed_params[:url],
+      initially_fetch: feed_params[:initially_fetch]
+    )
 
     if result.created?
       flash[:notice] = 'Feed was successfully added.'
@@ -53,6 +57,6 @@ class FeedsController < ApplicationController
   private
 
   def feed_params
-    params.require(:feed).permit(:url)
+    params.require(:feed).permit(:url, :initially_fetch)
   end
 end

--- a/app/frontend/components/NewFeedButton.jsx
+++ b/app/frontend/components/NewFeedButton.jsx
@@ -19,6 +19,7 @@ export default function NewFeedButton() {
     clearErrors,
   } = useForm({
     url: "",
+    initially_fetch: "three_days_ago",
   });
 
   function closeModal() {
@@ -86,26 +87,54 @@ export default function NewFeedButton() {
                   </div>
                 </div>
               </div>
-              <div className="p-6">
-                <div className="relative rounded-lg border border-slate-300 px-3 py-2 focus-within:border-cyan-600 focus-within:ring-0 focus-within:ring-cyan-600">
-                  <label
-                    htmlFor="name"
-                    className="absolute -top-2 left-2 -mt-px inline-block bg-white px-1 font-mono text-xs font-medium text-slate-800"
-                  >
-                    URL
-                  </label>
-                  <input
-                    value={data.url}
-                    onChange={(e) => setData("url", e.target.value)}
-                    type="text"
-                    name="name"
-                    id="name"
-                    className="block w-full border-0 p-0 text-sm text-slate-800 placeholder-gray-500 focus:ring-0"
-                    placeholder="https://daringfireball.net/feed"
-                  />
+              <div className="space-y-6 p-6">
+                <div className="">
+                  <div className="relative rounded-lg border border-slate-300 px-3 py-2 focus-within:border-cyan-600 focus-within:ring-0 focus-within:ring-cyan-600">
+                    <label
+                      htmlFor="name"
+                      className="absolute -top-2 left-2 -mt-px inline-block bg-white px-1 font-mono text-xs font-medium text-slate-800"
+                    >
+                      URL
+                    </label>
+                    <input
+                      value={data.url}
+                      onChange={(e) => setData("url", e.target.value)}
+                      type="text"
+                      name="name"
+                      id="name"
+                      className="block w-full border-0 p-0 text-sm text-slate-800 placeholder-gray-500 focus:ring-0"
+                      placeholder="https://daringfireball.net/feeds/main"
+                    />
+                  </div>
+                  {errors.url && <div className="">{errors.url}</div>}
                 </div>
-                {errors.url && <div className="">{errors.url}</div>}
+                <div className="">
+                  <div className="relative rounded-lg border border-slate-300 px-3 py-2 focus-within:border-cyan-600 focus-within:ring-0 focus-within:ring-cyan-600">
+                    <label
+                      htmlFor="initially-fetch"
+                      className="absolute -top-2 left-2 -mt-px inline-block bg-white px-1 font-mono text-xs font-medium text-slate-800"
+                    >
+                      Initially Fetch
+                    </label>
+                    <select
+                      id="initially-fetch"
+                      value={data.initially_fetch}
+                      onChange={(e) =>
+                        setData("initially_fetch", e.target.value)
+                      }
+                      className="block w-full border-0 p-0 text-sm text-slate-800 placeholder-gray-500 focus:ring-0"
+                    >
+                      <option value="one_day_ago">Last 24 Hours</option>
+                      <option value="three_days_ago" selected="selected">
+                        Last 3 Days
+                      </option>
+                      <option value="one_week_ago">Last 7 Days</option>
+                      <option value="two_weeks_ago">Last 2 Weeks</option>
+                    </select>
+                  </div>
+                </div>
               </div>
+
               <div className="p-6 pt-0 sm:grid sm:grid-flow-row-dense sm:grid-cols-2 sm:gap-3">
                 <button
                   disabled={processing}

--- a/app/models/time_string_parser.rb
+++ b/app/models/time_string_parser.rb
@@ -1,0 +1,16 @@
+class TimeStringParser
+  def self.parse(string)
+    case string.to_sym
+    when :one_day_ago
+      1.day.ago
+    when :three_days_ago
+      3.days.ago
+    when :one_week_ago
+      1.week.ago
+    when :two_weeks_ago
+      2.weeks.ago
+    else
+      raise "Invalid string value: #{string}"
+    end
+  end
+end

--- a/app/services/feed_creator.rb
+++ b/app/services/feed_creator.rb
@@ -4,10 +4,14 @@ class FeedCreator
     @parser = Feedjira
   end
 
-  def create_feed(current_account, url:)
+  def create_feed(current_account, url:, initially_fetch: :one_week_ago)
     feed = current_account.feeds.build
     parsed_feed = retrieve_feed(url)
-    feed.assign_attributes(name: parsed_feed.title, url: url)
+    feed.assign_attributes(
+      name: parsed_feed.title,
+      url: url,
+      last_fetched_at: set_last_fetched_at(initially_fetch)
+    )
     feed.save
 
     Result.new(created: feed.valid?, feed: feed)
@@ -21,6 +25,10 @@ class FeedCreator
   def retrieve_feed(url)
     xml = @http.get(url).body
     @parser.parse(xml)
+  end
+
+  def set_last_fetched_at(initial_fetch)
+    TimeStringParser.parse(initial_fetch)
   end
 
   class Result

--- a/app/services/feed_fetcher.rb
+++ b/app/services/feed_fetcher.rb
@@ -9,6 +9,7 @@ class FeedFetcher
   def fetch_items
     items = []
     get_entries.each do |entry|
+      break if entry_published_before_last_fetch?(entry)
       next if item_already_present?(entry)
 
       result = ItemCreator.new(entry: entry, feed: @feed).create_item
@@ -27,6 +28,10 @@ class FeedFetcher
   def get_entries
     xml = @http.get(@feed.url).body
     @parser.parse(xml).entries
+  end
+
+  def entry_published_before_last_fetch?(entry)
+    entry.published.to_time < @feed.last_fetched_at
   end
 
   def item_already_present?(entry)

--- a/spec/models/time_string_parser_spec.rb
+++ b/spec/models/time_string_parser_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe TimeStringParser, type: :model do
+  describe '.parse' do
+    it 'returns correct time for one_day_ago' do
+      freeze_time do
+        time = TimeStringParser.parse('one_day_ago')
+        expect(time).to eq(1.day.ago)
+      end
+    end
+
+    it 'returns correct time for three_days_ago' do
+      freeze_time do
+        time = TimeStringParser.parse('three_days_ago')
+        expect(time).to eq(3.days.ago)
+      end
+    end
+
+    it 'returns correct time for one_week_ago' do
+      freeze_time do
+        time = TimeStringParser.parse('one_week_ago')
+        expect(time).to eq(1.week.ago)
+      end
+    end
+
+    it 'returns correct time for two_weeks_ago' do
+      freeze_time do
+        time = TimeStringParser.parse('two_weeks_ago')
+        expect(time).to eq(2.weeks.ago)
+      end
+    end
+
+    it 'raises error for invalid string' do
+      freeze_time do
+        expect { TimeStringParser.parse('invalid_string') }.to raise_error('Invalid string value: invalid_string')
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,6 +54,9 @@ RSpec.configure do |config|
     driven_by :cuprite
   end
 
+  # Alternative to TimeCop
+  config.include ActiveSupport::Testing::TimeHelpers
+
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 

--- a/spec/services/feed_creator_spec.rb
+++ b/spec/services/feed_creator_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe FeedCreator, type: :model do
       end
     end
 
+    it 'sets correct last_fetched_date for initial fetch' do
+      VCR.use_cassette :valid_feed do
+        freeze_time do
+          account = create(:account)
+          url = 'https://daringfireball.net/feeds/main'
+
+          result = FeedCreator.new.create_feed(account, url: url, initially_fetch: :one_week_ago)
+
+          expect(result.feed.last_fetched_at).to eq(7.days.ago)
+        end
+      end
+    end
+
     it 'returns failure result object with invalid url' do
       account = create(:account)
       url = 'wefwef'

--- a/spec/services/feed_fetcher_spec.rb
+++ b/spec/services/feed_fetcher_spec.rb
@@ -8,15 +8,59 @@ RSpec.describe FeedFetcher, type: :model do
         :feed,
         account: account,
         name: 'Daring Fireball',
-        url: 'https://daringfireball.net/feeds/main'
+        url: 'https://daringfireball.net/feeds/main',
+        last_fetched_at: 1.week.ago
       )
 
-      VCR.use_cassette(:valid_feed) do
-        result = FeedFetcher.new(feed: feed).fetch_items
+      feed_fetcher = FeedFetcher.new(feed: feed)
 
-        expect(result.successful?).to eq(true)
-        expect(result.fetched_items_count).to eq(48)
+      allow(feed_fetcher).to receive(:get_entries) do
+        [
+          double(
+            :entry,
+            title: 'New Item',
+            url: 'url',
+            published: 1.day.ago,
+            content: 'Content',
+            entry_id: '1'
+          ),
+        ]
       end
+
+      result = feed_fetcher.fetch_items
+
+      expect(result.successful?).to eq(true)
+      expect(result.fetched_items_count).to eq(1)
+    end
+
+    it 'does not import items older than feed last_fetched_at date' do
+      account = create(:account)
+      feed = create(:feed, account: account, last_fetched_at: 7.days.ago)
+      feed_fetcher = FeedFetcher.new(feed: feed)
+      allow(feed_fetcher).to receive(:get_entries) do
+        [
+          double(
+            :entry,
+            title: 'New Item',
+            url: 'url',
+            published: 1.day.ago,
+            content: 'Content',
+            entry_id: '1'
+          ),
+          double(
+            :entry,
+            title: 'Old Item',
+            url: 'url',
+            published: 2.weeks.ago,
+            content: 'Content',
+            entry_id: '1'
+          ),
+        ]
+      end
+
+      result = feed_fetcher.fetch_items
+
+      expect(result.fetched_items_count).to eq(1)
     end
 
     it 'sets feed to inactive if error' do

--- a/spec/system/feeds/feed_management_spec.rb
+++ b/spec/system/feeds/feed_management_spec.rb
@@ -11,6 +11,7 @@ describe 'Managing Feeds', type: :system do
       visit feeds_path
       find('#new-feed-button').click
       fill_in 'URL', with: 'https://daringfireball.net/feeds/main'
+      select 'Last 7 Days', from: 'Initially Fetch'
       click_on 'Add Feed'
 
       expect(page).to have_content('Feed was successfully added.')
@@ -44,7 +45,7 @@ describe 'Managing Feeds', type: :system do
       find('.feed-menu-button').click
       click_on 'Refresh'
 
-      expect(page).to have_content "48 new item added to #{feed.name}."
+      expect(page).to have_content "0 new item added to #{feed.name}."
     end
   end
 end


### PR DESCRIPTION
Previously, when a new feed was added it would attempt to fetch
all entries available for a feed. Depending on the feed this could be
just a handful of entries (e.g. Daring Fireball: 48) or it could
be hundreds (Six Colors: 400+).

Now when adding a feed, a user can choose how far back to initially
get items (24 hours - 2 weeks). This is achieved by passing in the
value to set on the feed and then adding a break clause which stops
looping through entries when it comes across an entry that was added
before the last_fetched_at time.

A positive side effect is that this will greatly reduce the response
time for a feed refresh as it will break off when it reaches
feed items it will have already imported on the last feed import.