### PR TITLE
Adds a non-ActiveRecord factory for entries

### DIFF
--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -1,0 +1,29 @@
+# This is a non-active record object to make
+# testing RSS entries easier and avoids having to build a large
+# number of doubles throughout the spec suite
+
+# usage: `build(:entry)` (and pass in override values as necessary)
+
+class Entry
+  attr_reader :title, :content, :url, :published, :entry_id
+  def initialize(title, content, url, published, entry_id)
+    @title = title
+    @content = content
+    @url = url
+    @published = published
+    @entry_id = entry_id
+  end
+end
+
+FactoryBot.define do
+  factory :entry do
+    sequence(:title) { |n| "Entry #{n}" }
+    content { "Content" }
+    url { Faker::Internet.url }
+    published { 1.day.ago }
+    sequence(:entry_id) { |n| "entry-id-#{n}" }
+
+    skip_create
+    initialize_with { new(title, content, url, published, entry_id) }
+  end
+end

--- a/spec/services/feed_fetcher_spec.rb
+++ b/spec/services/feed_fetcher_spec.rb
@@ -15,16 +15,7 @@ RSpec.describe FeedFetcher, type: :model do
       feed_fetcher = FeedFetcher.new(feed: feed)
 
       allow(feed_fetcher).to receive(:get_entries) do
-        [
-          double(
-            :entry,
-            title: 'New Item',
-            url: 'url',
-            published: 1.day.ago,
-            content: 'Content',
-            entry_id: '1'
-          ),
-        ]
+        [build(:entry)]
       end
 
       result = feed_fetcher.fetch_items
@@ -39,22 +30,8 @@ RSpec.describe FeedFetcher, type: :model do
       feed_fetcher = FeedFetcher.new(feed: feed)
       allow(feed_fetcher).to receive(:get_entries) do
         [
-          double(
-            :entry,
-            title: 'New Item',
-            url: 'url',
-            published: 1.day.ago,
-            content: 'Content',
-            entry_id: '1'
-          ),
-          double(
-            :entry,
-            title: 'Old Item',
-            url: 'url',
-            published: 2.weeks.ago,
-            content: 'Content',
-            entry_id: '1'
-          ),
+          build(:entry, published: 1.day.ago),
+          build(:entry, published: 2.weeks.ago),
         ]
       end
 

--- a/spec/services/item_creator_spec.rb
+++ b/spec/services/item_creator_spec.rb
@@ -4,14 +4,7 @@ RSpec.describe ItemCreator, type: :model do
   context '.create_item' do
     it 'returns successful result object' do
       feed = create(:feed)
-      entry = double(
-        :entry,
-        title: 'The Title',
-        url: 'url',
-        published: Time.now,
-        content: 'Content',
-        entry_id: '123'
-      )
+      entry = build(:entry)
 
       result = ItemCreator.new(entry: entry, feed: feed).create_item
 
@@ -20,14 +13,7 @@ RSpec.describe ItemCreator, type: :model do
 
     it 'returns failure result object if item invalid' do
       feed = create(:feed)
-      entry = double(
-        :entry,
-        title: '',
-        url: '',
-        published: '',
-        content: '',
-        entry_id: ''
-      )
+      entry = build(:entry, title: nil)
 
       result = ItemCreator.new(entry: entry, feed: feed).create_item
 


### PR DESCRIPTION
Entries are received from the RSS feed fetcher and as part of testing
commonly stubbed. In order to keep the spec suites focused with less
setup this adds a non-AR factory to easily generate entries when
necessary for testing.