### PR TITLE
Stops last infinte scroll page being re-requested

### DIFF
--- a/app/frontend/components/Reader/Index.jsx
+++ b/app/frontend/components/Reader/Index.jsx
@@ -13,7 +13,7 @@ export default function Reader() {
   const [scrollItems, setScrollItems] = useState([]);
 
   useEffect(() => {
-    if (!isVisible) {
+    if (!isVisible || pagy.page === pagy.last) {
       return;
     }
     Inertia.visit(pagy.next_url, {
@@ -36,12 +36,19 @@ export default function Reader() {
           ))}
         </ul>
         <div className="my-5 flex justify-center">
-          <div
-            ref={loadingPill}
-            className="inline-flex animate-pulse items-center justify-center rounded-full bg-slate-100 px-4 py-2 font-mono text-sm font-medium text-slate-500"
-          >
-            <span>Loading...</span>
-          </div>
+          {pagy.page === pagy.last && (
+            <div className="inline-flex items-center justify-center rounded-full bg-slate-100 px-4 py-2 font-mono text-sm font-medium text-slate-500">
+              <span>No More Items!</span>
+            </div>
+          )}
+          {pagy.page < pagy.last && (
+            <div
+              ref={loadingPill}
+              className="inline-flex animate-pulse items-center justify-center rounded-full bg-slate-100 px-4 py-2 font-mono text-sm font-medium text-slate-500"
+            >
+              <span>Loading...</span>
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added a guard statement that stops fetching the next pagy page
if the current page === last page.

Also includes a small UI element to inform the user that they
have reached the end of the list of items.