### PR TITLE
Adds column of feed items

### DIFF
--- a/app/controllers/feeds/items_controller.rb
+++ b/app/controllers/feeds/items_controller.rb
@@ -4,14 +4,13 @@ class Feeds::ItemsController < ApplicationController
   def index
     feeds = current_account.feeds.order(created_at: :desc).select(:id, :name)
     feed = current_account.feeds.find(params[:feed_id])
-    pagy, items = pagy(feed.items.unread.order(published_at: :desc))
+    items = feed.items.unread.order(published_at: :desc)
 
     render inertia: 'Unread/Index',
            props: {
              items: items,
              feeds: feeds,
              feed: feed,
-             pagy: pagy_metadata(pagy),
            }
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,8 +3,8 @@ class ItemsController < ApplicationController
 
   def index
     feeds = current_account.feeds.order(created_at: :desc).select(:id, :name)
-    pagy, items = pagy(current_account.items.unread.order(published_at: :desc))
+    items = current_account.items.unread.order(published_at: :desc)
 
-    render inertia: 'Unread/Index', props: { items: items, feeds: feeds, pagy: pagy_metadata(pagy) }
+    render inertia: 'Unread/Index', props: { items: items, feeds: feeds }
   end
 end

--- a/app/frontend/components/Reader/Index.jsx
+++ b/app/frontend/components/Reader/Index.jsx
@@ -1,56 +1,17 @@
-import React, { useState, useRef, useEffect } from "react";
+import React from "react";
 import { usePage } from "@inertiajs/inertia-react";
-import { Inertia } from "@inertiajs/inertia";
 import FeedSidebar from "@/components/Reader/FeedSidebar";
 import FeedItemPanel from "@/components/Reader/FeedItemPanel";
-import useIsVisible from "@/utils/hooks";
+import ItemsSidebar from "@/components/Reader/ItemsSidebar";
 
 export default function Reader() {
-  const { items, pagy } = usePage().props;
-  const loadingPill = useRef(null);
-  const isVisible = useIsVisible(loadingPill);
-
-  const [scrollItems, setScrollItems] = useState([]);
-
-  useEffect(() => {
-    if (!isVisible || pagy.page === pagy.last) {
-      return;
-    }
-    Inertia.visit(pagy.next_url, {
-      preserveState: true,
-      preserveScroll: true,
-    });
-  }, [isVisible]);
-
-  useEffect(() => {
-    setScrollItems([...scrollItems, ...items]);
-  }, [items]);
+  const { items } = usePage().props;
 
   return (
     <div className="flex h-screen">
       <FeedSidebar />
-      <div className="flex-1 overflow-y-scroll">
-        <ul className="">
-          {scrollItems?.map((item) => (
-            <FeedItemPanel key={item.id} item={item} />
-          ))}
-        </ul>
-        <div className="my-5 flex justify-center">
-          {pagy.page === pagy.last && (
-            <div className="inline-flex items-center justify-center rounded-full bg-slate-100 px-4 py-2 font-mono text-sm font-medium text-slate-500">
-              <span>No More Items!</span>
-            </div>
-          )}
-          {pagy.page < pagy.last && (
-            <div
-              ref={loadingPill}
-              className="inline-flex animate-pulse items-center justify-center rounded-full bg-slate-100 px-4 py-2 font-mono text-sm font-medium text-slate-500"
-            >
-              <span>Loading...</span>
-            </div>
-          )}
-        </div>
-      </div>
+      <ItemsSidebar />
+      {items.length > 0 && <FeedItemPanel item={items[0]} />}
     </div>
   );
 }

--- a/app/frontend/components/Reader/ItemsSidebar.jsx
+++ b/app/frontend/components/Reader/ItemsSidebar.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { usePage, Link } from "@inertiajs/inertia-react";
+
+export default function ItemsSidebar() {
+  const { items } = usePage().props;
+
+  return (
+    <div className=" w-80 overflow-y-scroll border-r border-slate-100">
+      <div className="divide-y divide-slate-100 overflow-y-scroll">
+        {items.map(({ id, title, published_at }) => (
+          <div key={id} className="w-full">
+            <Link
+              href="/"
+              preserveScroll
+              preserveState
+              className=" block p-3 transition hover:bg-slate-100 active:bg-white active:hover:bg-white"
+            >
+              <h3 className="truncate text-sm font-medium text-slate-700">
+                {title}
+              </h3>
+              <span className="mt-2 block font-mono text-xs text-slate-500">
+                {" "}
+                {new Date(published_at).toLocaleDateString()}
+              </span>
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Instead of using a continuous feed that is scrolled through
items will are listed in a sidebar. This lays the groundwork for
each an item being clicked on and routed to the show page for that
resource.

It removes the infinite scroll for now and currently just shows
the first item in the feed.