### PR TITLE
Adds user refreshing all feeds at once

### DIFF
--- a/app/controllers/manage/feeds_controller.rb
+++ b/app/controllers/manage/feeds_controller.rb
@@ -55,6 +55,15 @@ class Manage::FeedsController < ApplicationController
     end
   end
 
+  def refresh_all
+    current_account.feeds.active.each do |feed|
+      RefreshFeedJob.perform_async(feed.id)
+    end
+
+    flash[:notice] = 'Checking for new items...'
+    redirect_back fallback_location: feeds_path
+  end
+
   private
 
   def feed_params

--- a/app/frontend/Layouts/Authenticated.jsx
+++ b/app/frontend/Layouts/Authenticated.jsx
@@ -1,9 +1,14 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { usePage, Link } from "@inertiajs/inertia-react";
-import { CogIcon } from "@heroicons/react/solid";
+import { CogIcon, RefreshIcon } from "@heroicons/react/solid";
 
-import { destroy_account_session_path, feeds_path, root_path } from "@/routes";
+import {
+  destroy_account_session_path,
+  feeds_path,
+  root_path,
+  refresh_all_feeds_path,
+} from "@/routes";
 import FlashMessages from "@/components/FlashMessages";
 import NewFeedButton from "@/components/NewFeedButton";
 import Dropdown from "@/components/Dropdown";
@@ -86,6 +91,14 @@ function Header() {
       </div>
 
       <div className="flex w-40 justify-end space-x-2">
+        <Link
+          href={refresh_all_feeds_path()}
+          as="button"
+          method="patch"
+          className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-cyan-600 to-cyan-500 active:scale-95"
+        >
+          <RefreshIcon className="h-4 w-4 text-white" />
+        </Link>
         <NewFeedButton />
       </div>
     </header>

--- a/app/frontend/routes.d.ts
+++ b/app/frontend/routes.d.ts
@@ -549,6 +549,16 @@ export const rails_service_blob_proxy_path: ((
 
 /**
  * Generates rails route to
+ * /manage/feeds/refresh_all(.:format)
+ * @param {object | undefined} options
+ * @returns {string} route path
+ */
+export const refresh_all_feeds_path: ((
+  options?: {format?: OptionalRouteParameter} & RouteOptions
+) => string) & RouteHelperExtras;
+
+/**
+ * Generates rails route to
  * /manage/feeds/:id/refresh(.:format)
  * @param {any} id
  * @param {object | undefined} options

--- a/app/frontend/routes.js
+++ b/app/frontend/routes.js
@@ -869,6 +869,14 @@ export const rails_service_blob_proxy_path = __jsr.r({"signed_id":{"r":true},"fi
 
 /**
  * Generates rails route to
+ * /manage/feeds/refresh_all(.:format)
+ * @param {object | undefined} options
+ * @returns {string} route path
+ */
+export const refresh_all_feeds_path = __jsr.r({"format":{}}, [2,[7,"/"],[2,[6,"manage"],[2,[7,"/"],[2,[6,"feeds"],[2,[7,"/"],[2,[6,"refresh_all"],[1,[2,[8,"."],[3,"format"]]]]]]]]]);
+
+/**
+ * Generates rails route to
  * /manage/feeds/:id/refresh(.:format)
  * @param {any} id
  * @param {object | undefined} options

--- a/app/services/feed_fetcher.rb
+++ b/app/services/feed_fetcher.rb
@@ -18,7 +18,7 @@ class FeedFetcher
 
     @feed.update(last_fetched_at: Time.now, status: :active)
     Result.new(successful: true, fetched_items_count: items.size)
-  rescue Errno::ECONNREFUSED, Feedjira::NoParserAvailable, Addressable::URI::InvalidURIError
+  rescue Errno::ECONNREFUSED, Feedjira::NoParserAvailable, Addressable::URI::InvalidURIError, SocketError
     @feed.update(status: :inactive)
     Result.new(successful: false, feed: @feed)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       scope module: 'manage', path: 'manage' do
         resources :feeds, only: [:create, :index, :destroy] do
           patch :refresh, on: :member
+          patch :refresh_all, on: :collection
         end
       end
 

--- a/spec/factories/feeds.rb
+++ b/spec/factories/feeds.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :feed do
-    status { [0, 1].sample }
+    status { :active }
     url { Faker::Internet.url(path: '/feed') }
     name { Faker::App.name }
     last_fetched_at { Faker::Time.between(from: 1.day.ago, to: Time.now) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,6 +58,10 @@ RSpec.configure do |config|
   # Alternative to TimeCop
   config.include ActiveSupport::Testing::TimeHelpers
 
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
+
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 

--- a/spec/requests/refresh_feed_spec.rb
+++ b/spec/requests/refresh_feed_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'Refreshing all feeds', type: :request, inertia: true do
+  it 'enqueues refresh jobs for all active feeds' do
+    account = create(:account)
+    login_as(account)
+    create_list(:feed, 3, account: account)
+
+    patch refresh_all_feeds_path
+    follow_redirect!
+
+    expect(inertia.props[:flash][:success]).to include('Checking for new items...')
+    expect(RefreshFeedJob.jobs.size).to eq(3)
+  end
+end


### PR DESCRIPTION
Using a non-restful route until I can come up with a better
convention for refreshes.

Also removes the random active/inactive state from the feed factory.
This was very dumb to have set as I couldn't figure out why I was
getting inconsistent job queue lengths in specs.