### PR TITLE
Populates item content with entry summary

### DIFF
--- a/app/services/item_creator.rb
+++ b/app/services/item_creator.rb
@@ -9,7 +9,7 @@ class ItemCreator
       title: @entry.title,
       permalink: @entry.url,
       published_at: @entry.published,
-      content: @entry.content,
+      content: @entry.content || @entry.summary,
       feed_id: @feed.id,
       entry_id: @entry.entry_id
     )

--- a/spec/factories/entries.rb
+++ b/spec/factories/entries.rb
@@ -5,10 +5,11 @@
 # usage: `build(:entry)` (and pass in override values as necessary)
 
 class Entry
-  attr_reader :title, :content, :url, :published, :entry_id
-  def initialize(title, content, url, published, entry_id)
+  attr_reader :title, :content, :summary, :url, :published, :entry_id
+  def initialize(title, content, summary, url, published, entry_id)
     @title = title
     @content = content
+    @summary = summary
     @url = url
     @published = published
     @entry_id = entry_id
@@ -22,8 +23,9 @@ FactoryBot.define do
     url { Faker::Internet.url }
     published { 1.day.ago }
     sequence(:entry_id) { |n| "entry-id-#{n}" }
+    summary { "Summary" }
 
     skip_create
-    initialize_with { new(title, content, url, published, entry_id) }
+    initialize_with { new(title, content, summary, url, published, entry_id) }
   end
 end

--- a/spec/services/item_creator_spec.rb
+++ b/spec/services/item_creator_spec.rb
@@ -19,5 +19,14 @@ RSpec.describe ItemCreator, type: :model do
 
       expect(result.created?).to eq(false)
     end
+
+    it 'uses summary if no content present' do
+      feed = create(:feed)
+      entry = build(:entry, content: nil, summary: 'summary')
+
+      result = ItemCreator.new(entry: entry, feed: feed).create_item
+
+      expect(result.item.content).to eq(entry.summary)
+    end
   end
 end


### PR DESCRIPTION
Some feeds only provide a summary attribute. If the content is empty
we now fallback to the summary.