### PR TITLE
Adds simple item pagination

### DIFF
--- a/app/controllers/all/feeds/items_controller.rb
+++ b/app/controllers/all/feeds/items_controller.rb
@@ -2,17 +2,24 @@ class All::Feeds::ItemsController < ApplicationController
   before_action :authenticate_account!
 
   def show
+    item = current_account.items.find(params[:id])
     feeds = current_account.feeds.includes(:items)
     feed = feeds.find { |i| i.id == params[:feed_id].to_i }
-    items = feed.items
-    item = items.find { |i| i.id == params[:id].to_i }
+    pagy, records = pagy(feed.items, page: item_page(item), items: 30)
 
     render inertia: 'Unread/Index',
            props: {
              feeds: Read::FeedResource.new(feeds).serializable_hash,
+             items: ItemResource.new(records, params: { context: :feed }).serializable_hash,
              feed: feed,
-             items: ItemResource.new(items, params: { context: :feed }).serializable_hash,
              item: item,
+             pagy: pagy_metadata(pagy),
            }
+  end
+
+  private
+
+  def item_page(item)
+    params[:page].present? ? params[:page].to_i : ItemPage.new(current_account, item, target: :feed).page
   end
 end

--- a/app/controllers/all/items_controller.rb
+++ b/app/controllers/all/items_controller.rb
@@ -3,25 +3,33 @@ class All::ItemsController < ApplicationController
 
   def index
     feeds = current_account.feeds.includes(:items)
-    items = current_account.items.order(published_at: :desc)
+    pagy, records = pagy(current_account.items, items: 30)
 
     render inertia: 'Unread/Index', props: {
-      items: ItemResource.new(items).serializable_hash,
+      items: ItemResource.new(records).serializable_hash,
       feeds: Read::FeedResource.new(feeds).serializable_hash,
+      pagy: pagy_metadata(pagy),
     }
   end
 
   def show
+    item = current_account.items.find(params[:id])
     feeds = current_account.feeds.includes(:items)
-    items = current_account.items.order(published_at: :desc)
-    item = items.find { |i| i.id == params[:id].to_i }
+    pagy, records = pagy(current_account.items, page: item_page(item), items: 30)
     feed = feeds.find { |i| i.id == item.feed_id }
 
     render inertia: 'Unread/Index', props: {
-      items: ItemResource.new(items).serializable_hash,
+      items: ItemResource.new(records).serializable_hash,
       feeds: Read::FeedResource.new(feeds).serializable_hash,
       feed: feed,
       item: item,
+      pagy: pagy_metadata(pagy),
     }
+  end
+
+  private
+
+  def item_page(item)
+    params[:page].present? ? params[:page].to_i : ItemPage.new(current_account, item, target: :all).page
   end
 end

--- a/app/controllers/unread/feeds/items_controller.rb
+++ b/app/controllers/unread/feeds/items_controller.rb
@@ -2,17 +2,24 @@ class Unread::Feeds::ItemsController < ApplicationController
   before_action :authenticate_account!
 
   def show
+    item = current_account.unread_items.find(params[:id])
     feeds = current_account.feeds.includes(:unread_items)
     feed = feeds.find { |i| i.id == params[:feed_id].to_i }
-    items = feed.unread_items
-    item = items.find { |i| i.id == params[:id].to_i }
+    pagy, records = pagy(feed.unread_items, page: item_page(item), items: 30)
 
     render inertia: 'Unread/Index',
            props: {
-             feeds: Unread::FeedResource.new(feeds).serializable_hash,
              feed: feed,
-             items: Unread::Feed::ItemResource.new(items).serializable_hash,
+             feeds: Unread::FeedResource.new(feeds).serializable_hash,
+             items: Unread::Feed::ItemResource.new(records).serializable_hash,
              item: item,
+             pagy: pagy_metadata(pagy),
            }
+  end
+
+  private
+
+  def item_page(item)
+    params[:page].present? ? params[:page].to_i : ItemPage.new(current_account, item, target: :unread_feed).page
   end
 end

--- a/app/controllers/unread/items_controller.rb
+++ b/app/controllers/unread/items_controller.rb
@@ -3,25 +3,33 @@ class Unread::ItemsController < ApplicationController
 
   def index
     feeds = current_account.feeds.includes(:unread_items)
-    items = current_account.unread_items
+    pagy, records = pagy(current_account.unread_items, items: 30)
 
     render inertia: 'Unread/Index', props: {
-      items: Unread::ItemResource.new(items).serializable_hash,
+      items: Unread::ItemResource.new(records).serializable_hash,
       feeds: Unread::FeedResource.new(feeds).serializable_hash,
+      pagy: pagy_metadata(pagy),
     }
   end
 
   def show
+    item = current_account.unread_items.find(params[:id])
     feeds = current_account.feeds.includes(:unread_items)
-    items = current_account.unread_items
-    item = items.find { |i| i.id == params[:id].to_i }
+    pagy, records = pagy(current_account.unread_items, page: item_page(item), items: 30)
     feed = feeds.find { |i| i.id == item.feed_id }
 
     render inertia: 'Unread/Index', props: {
-      items: Unread::ItemResource.new(items).serializable_hash,
+      items: Unread::ItemResource.new(records).serializable_hash,
       feeds: Unread::FeedResource.new(feeds).serializable_hash,
       feed: feed,
       item: item,
+      pagy: pagy_metadata(pagy),
     }
+  end
+
+  private
+
+  def item_page(item)
+    params[:page].present? ? params[:page].to_i : ItemPage.new(current_account, item, target: :all_unread).page
   end
 end

--- a/app/frontend/components/Reader/ItemsSidebar.jsx
+++ b/app/frontend/components/Reader/ItemsSidebar.jsx
@@ -1,11 +1,19 @@
 import React, { useRef } from "react";
 import { usePage, Link } from "@inertiajs/inertia-react";
 import Draggable from "react-draggable";
+import { Inertia } from "@inertiajs/inertia";
 import { useResizableX } from "@/utils/hooks";
 
 export default function ItemsSidebar() {
-  const { items } = usePage().props;
+  const { items, pagy } = usePage().props;
   const { url } = usePage();
+
+  const nextPage = () => {
+    Inertia.visit(pagy.next_url, {
+      preserveState: true,
+      preserveScroll: true,
+    });
+  };
 
   const resizeable = useRef(null);
   const { start, resize, width, end } = useResizableX(
@@ -46,6 +54,14 @@ export default function ItemsSidebar() {
             </Link>
           </div>
         ))}
+        <button
+          type="button"
+          disabled={pagy.page === pagy.last}
+          onClick={nextPage}
+          className="block w-full py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
+        >
+          {pagy.page === pagy.last ? "That's all for now!" : "Next"}
+        </button>
       </div>
     </div>
   );

--- a/app/models/item_page.rb
+++ b/app/models/item_page.rb
@@ -1,0 +1,38 @@
+class ItemPage
+  def initialize(current_account, item, target:)
+    @current_account = current_account
+    @item = item
+    @target = target
+    @per_page = 30
+  end
+
+  def page
+    (position / @per_page) == 0 ? 1 : (position / @per_page).ceil + 1
+  end
+
+  private
+
+  def position
+    target_items.where("published_at >= ?", @item.send(:published_at)).count
+  end
+
+  def target_items
+    send(@target, @item.feed_id)
+  end
+
+  def all(_)
+    @current_account.items
+  end
+
+  def feed(feed_id)
+    @current_account.items.where(feed_id: feed_id)
+  end
+
+  def all_unread(_)
+    @current_account.unread_items
+  end
+
+  def unread_feed(feed_id)
+    @current_account.unread_items.where(feed_id: feed_id)
+  end
+end

--- a/spec/models/item_page_spec.rb
+++ b/spec/models/item_page_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe ItemPage, type: :model do
+  it 'returns correct page number for all items' do
+    account = create(:account)
+    create_list(:item, 90, account: account)
+    item = create(:item, account: account, published_at: Time.now)
+
+    page_number = ItemPage.new(account, item, target: :all).page
+
+    expect(page_number).to eq(1)
+  end
+
+  it 'returns the correct page number for unread items' do
+    account = create(:account)
+    create_list(:unread_item, 90, account: account)
+    create_list(:read_item, 60, account: account)
+    item = create(:unread_item, account: account, published_at: Time.now)
+
+    page_number = ItemPage.new(account, item, target: :all_unread).page
+
+    expect(page_number).to eq(1)
+  end
+
+  it 'returns the correct page number for feed items' do
+    account = create(:account)
+    feed = create(:feed, account: account)
+    create_list(:item, 90, account: account, feed: feed)
+    item = create(:item, feed: feed, account: account, published_at: Time.now)
+
+    page_number = ItemPage.new(account, item, target: :feed).page
+
+    expect(page_number).to eq(1)
+  end
+
+  it 'returns the correct page number for unread feed items' do
+    account = create(:account)
+    feed = create(:feed, account: account)
+    create_list(:unread_item, 90, account: account)
+    create_list(:read_item, 90, account: account, feed: feed)
+    item = create(:unread_item, feed: feed, account: account, published_at: Time.now)
+
+    page_number = ItemPage.new(account, item, target: :unread_feed).page
+
+    expect(page_number).to eq(1)
+  end
+end

--- a/spec/system/reading/all_items_spec.rb
+++ b/spec/system/reading/all_items_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe 'Reading All Items', type: :system do
 
     it 'clicks on item to view content' do
       feed = create(:feed, account: @account, name: 'First Feed')
-      create(:item, feed: feed, published_at: Time.now)
-      last_item = create(:item, feed: feed, published_at: 2.days.ago)
+      create(:item, feed: feed, published_at: Time.now, account: @account)
+      last_item = create(:item, feed: feed, published_at: 2.days.ago, account: @account)
 
       visit items_path
       click_link 'First Feed'
@@ -57,6 +57,7 @@ RSpec.describe 'Reading All Items', type: :system do
       # Currently getting strange Capybara error that I can't debug
       # expect(page).to have_selector 'h1', text: last_item.title
       expect(page).to have_content last_item.content
+      sleep(0.1)
       expect(page.current_path).to eq feed_item_path(feed, last_item)
     end
   end

--- a/spec/system/reading/unread_items_spec.rb
+++ b/spec/system/reading/unread_items_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe 'Reading Unread Items', type: :system do
 
     it 'clicks on item to view content' do
       feed = create(:feed, account: @account, name: 'First Feed')
-      create(:unread_item, feed: feed, published_at: Time.now)
-      last_item = create(:item, feed: feed, published_at: 2.days.ago)
+      create(:unread_item, feed: feed, published_at: Time.now, account: @account)
+      last_item = create(:item, feed: feed, published_at: 2.days.ago, account: @account)
 
       visit unread_items_path
       click_link 'First Feed'


### PR DESCRIPTION
Main complexity is figuring out what page number an item is on and
getting that page's items. Not sure if the trade-off is right. Maybe
it would be better if it just went to the first paginated item if you
go to a an item direct... not even sure how often it matters.

For now the goal is to just stop grabbing every item and keep
response times and memory usage lower. Need to think a bit more
about how to get infinite scrolling in both directions sustainably.